### PR TITLE
Use big.Int instead of uint64s

### DIFF
--- a/pkg/encryption/elgamal/operations.go
+++ b/pkg/encryption/elgamal/operations.go
@@ -9,11 +9,10 @@ import (
 // For some Ciphertext that encodes x, (C = rH + xG, D = rP), we can just add amount*G to C.
 // The new Ciphertext C' will encode C' = rH + xG + amountG = rH + (x+amount)G.
 // We do not need to touch D, since the randomness has not changed.
-func (teg TwistedElGamal) AddScalar(ciphertext *Ciphertext, amount uint64) (*Ciphertext, error) {
+func (teg TwistedElGamal) AddScalar(ciphertext *Ciphertext, amount *big.Int) (*Ciphertext, error) {
 	G := teg.GetG()
 	// Create a scalar from the amount.
-	bigIntAmount := new(big.Int).SetUint64(amount)
-	scalarAmount, err := teg.curve.Scalar.SetBigInt(bigIntAmount)
+	scalarAmount, err := teg.curve.Scalar.SetBigInt(amount)
 	if err != nil {
 		return nil, err
 	}
@@ -32,11 +31,10 @@ func (teg TwistedElGamal) AddScalar(ciphertext *Ciphertext, amount uint64) (*Cip
 // For some Ciphertext that encodes x, (C = rH + xG, D = rP), we can just sub amount*G to C.
 // The new Ciphertext C' will encode C' = rH + xG - amountG = rH + (x-amount)G.
 // We do not need to touch D, since the randomness has not changed.
-func (teg TwistedElGamal) SubScalar(ciphertext *Ciphertext, amount uint64) (*Ciphertext, error) {
+func (teg TwistedElGamal) SubScalar(ciphertext *Ciphertext, amount *big.Int) (*Ciphertext, error) {
 	G := teg.GetG()
 	// Create a scalar from the amount.
-	bigIntAmount := new(big.Int).SetUint64(amount)
-	scalarAmount, err := teg.curve.Scalar.SetBigInt(bigIntAmount)
+	scalarAmount, err := teg.curve.Scalar.SetBigInt(amount)
 	if err != nil {
 		return nil, err
 	}
@@ -80,9 +78,8 @@ func SubtractCiphertext(ct1 *Ciphertext, ct2 *Ciphertext) (*Ciphertext, error) {
 }
 
 // ScalarMultCiphertext Multiply takes a ciphertext ct and returns the ciphertext of their ct * factor.
-func (teg TwistedElGamal) ScalarMultCiphertext(ct *Ciphertext, factor uint64) (*Ciphertext, error) {
-	scalarValue := new(big.Int).SetUint64(factor)
-	factorScalar, _ := teg.curve.Scalar.SetBigInt(scalarValue)
+func (teg TwistedElGamal) ScalarMultCiphertext(ct *Ciphertext, factor *big.Int) (*Ciphertext, error) {
+	factorScalar, _ := teg.curve.Scalar.SetBigInt(factor)
 
 	// Cmul = C * Factor
 	cMul := ct.C.Mul(factorScalar)
@@ -101,10 +98,10 @@ func (teg TwistedElGamal) ScalarMultCiphertext(ct *Ciphertext, factor uint64) (*
 // AddWithLoHi performs the operation: left_ciphertext + (right_ciphertext_lo + 2^16 * right_ciphertext_hi)
 func (teg TwistedElGamal) AddWithLoHi(leftCiphertext, rightCiphertextLo, rightCiphertextHi *Ciphertext) (*Ciphertext, error) {
 	// Step 1: Define shift_scalar as 2^16 (which is 65536)
-	shiftScalar := 1 << 16
+	shiftScalar := big.NewInt(1 << 16)
 
 	// Step 2: Shift rightCiphertextHi by multiplying by shift_scalar
-	shiftedRightCiphertextHi, err := teg.ScalarMultCiphertext(rightCiphertextHi, uint64(shiftScalar))
+	shiftedRightCiphertextHi, err := teg.ScalarMultCiphertext(rightCiphertextHi, shiftScalar)
 	if err != nil {
 		return nil, fmt.Errorf("failed to shift rightCiphertextHi: %v", err)
 	}
@@ -128,10 +125,10 @@ func (teg TwistedElGamal) AddWithLoHi(leftCiphertext, rightCiphertextLo, rightCi
 // SubWithLoHi performs the operation: left_ciphertext - (right_ciphertext_lo + 2^16 * right_ciphertext_hi)
 func (teg TwistedElGamal) SubWithLoHi(leftCiphertext, rightCiphertextLo, rightCiphertextHi *Ciphertext) (*Ciphertext, error) {
 	// Step 1: Define shift_scalar as 2^16 (which is 65536)
-	shiftScalar := 1 << 16
+	shiftScalar := big.NewInt(1 << 16)
 
 	// Step 2: Shift rightCiphertextHi by multiplying by shift_scalar
-	shiftedRightCiphertextHi, err := teg.ScalarMultCiphertext(rightCiphertextHi, uint64(shiftScalar))
+	shiftedRightCiphertextHi, err := teg.ScalarMultCiphertext(rightCiphertextHi, shiftScalar)
 	if err != nil {
 		return nil, fmt.Errorf("failed to shift rightCiphertextHi: %v", err)
 	}

--- a/pkg/encryption/elgamal/types_test.go
+++ b/pkg/encryption/elgamal/types_test.go
@@ -2,9 +2,11 @@ package elgamal
 
 import (
 	"encoding/json"
+	"math/big"
+	"testing"
+
 	testutils "github.com/sei-protocol/sei-cryptography/pkg/testing"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestCiphertext_MarshalJSON(t *testing.T) {
@@ -13,7 +15,7 @@ func TestCiphertext_MarshalJSON(t *testing.T) {
 
 	keys, _ := eg.KeyGen(*privateKey, DefaultTestDenom)
 
-	value := uint64(108)
+	value := big.NewInt(108)
 	ciphertext, _, _ := eg.Encrypt(keys.PublicKey, value)
 
 	// Marshal the Ciphertext to JSON

--- a/pkg/zkproofs/ciphertext_validity.go
+++ b/pkg/zkproofs/ciphertext_validity.go
@@ -4,9 +4,10 @@ import (
 	crand "crypto/rand"
 	"encoding/json"
 	"errors"
+	"math/big"
+
 	"github.com/coinbase/kryptology/pkg/core/curves"
 	"github.com/sei-protocol/sei-cryptography/pkg/encryption/elgamal"
-	"math/big"
 )
 
 // CiphertextValidityProof represents a zero-knowledge proof that a ciphertext is valid.
@@ -23,7 +24,7 @@ type CiphertextValidityProof struct {
 // - pubKey: The public key used in the encryption.
 // - ciphertext: The ciphertext to prove the validity of.
 // - message: The message that was encrypted in the ciphertext.
-func NewCiphertextValidityProof(pedersenOpening *curves.Scalar, pubKey curves.Point, ciphertext *elgamal.Ciphertext, message uint64) (*CiphertextValidityProof, error) {
+func NewCiphertextValidityProof(pedersenOpening *curves.Scalar, pubKey curves.Point, ciphertext *elgamal.Ciphertext, message *big.Int) (*CiphertextValidityProof, error) {
 	// Validate input
 	if pedersenOpening == nil {
 		return nil, errors.New("invalid randomness factor")
@@ -44,8 +45,7 @@ func NewCiphertextValidityProof(pedersenOpening *curves.Scalar, pubKey curves.Po
 
 	ed25519 := curves.ED25519()
 	// Convert message to a scalar
-	messageValue := new(big.Int).SetUint64(message)
-	x, _ := ed25519.Scalar.SetBigInt(messageValue)
+	x, _ := ed25519.Scalar.SetBigInt(message)
 
 	// Step 1: Generate random blinding factors for the proof
 	rBlind := ed25519.Scalar.Random(crand.Reader) // Blinding factor for random value r

--- a/pkg/zkproofs/ciphertext_validity_test.go
+++ b/pkg/zkproofs/ciphertext_validity_test.go
@@ -2,10 +2,12 @@ package zkproofs
 
 import (
 	"encoding/json"
+	"math/big"
+	"testing"
+
 	"github.com/sei-protocol/sei-cryptography/pkg/encryption/elgamal"
 	testutils "github.com/sei-protocol/sei-cryptography/pkg/testing"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestValidityProof(t *testing.T) {
@@ -16,7 +18,7 @@ func TestValidityProof(t *testing.T) {
 	keys, _ := eg.KeyGen(*privateKey, TestDenom)
 	altKeys, _ := eg.KeyGen(*altPrivateKey, TestDenom)
 
-	message12 := uint64(12)
+	message12 := big.NewInt(12)
 	ciphertext12, randomness12, err := eg.Encrypt(keys.PublicKey, message12)
 	require.Nil(t, err)
 
@@ -30,7 +32,7 @@ func TestValidityProof(t *testing.T) {
 	require.False(t, validated, "Validating with the wrong PublicKey should validate as false")
 
 	// Encrypt a message (e.g., x = 42)
-	message42 := uint64(42)
+	message42 := big.NewInt(42)
 	ciphertext42, randomness42, _ := eg.Encrypt(keys.PublicKey, message42)
 
 	validated = VerifyCiphertextValidity(proof12, altKeys.PublicKey, ciphertext42)
@@ -64,7 +66,7 @@ func TestCiphertextValidityProof_MarshalUnmarshalJSON(t *testing.T) {
 	eg := elgamal.NewTwistedElgamal()
 	keys, _ := eg.KeyGen(*privateKey, TestDenom)
 
-	message12 := uint64(12)
+	message12 := big.NewInt(12)
 	ciphertext12, randomness12, _ := eg.Encrypt(keys.PublicKey, message12)
 
 	original, err := NewCiphertextValidityProof(&randomness12, keys.PublicKey, ciphertext12, message12)
@@ -90,7 +92,7 @@ func TestNewCiphertextValidityProof_InvalidInput(t *testing.T) {
 	eg := elgamal.NewTwistedElgamal()
 	keys, _ := eg.KeyGen(*privateKey, TestDenom)
 
-	amount := uint64(100)
+	amount := big.NewInt(100)
 	// Encrypt the amount using source and destination public keys
 	ciphertext, randomness, _ := eg.Encrypt(keys.PublicKey, amount)
 
@@ -136,7 +138,7 @@ func TestVerifyCiphertextValidityProof_Invalid_Input(t *testing.T) {
 	eg := elgamal.NewTwistedElgamal()
 	keys, _ := eg.KeyGen(*privateKey, TestDenom)
 
-	amount := uint64(100)
+	amount := big.NewInt(100)
 	// Encrypt the amount using source and destination public keys
 	ciphertext, randomness, _ := eg.Encrypt(keys.PublicKey, amount)
 

--- a/pkg/zkproofs/zero_balance_test.go
+++ b/pkg/zkproofs/zero_balance_test.go
@@ -3,35 +3,37 @@ package zkproofs
 import (
 	"crypto/rand"
 	"encoding/json"
+	"math/big"
+	"testing"
+
 	"github.com/coinbase/kryptology/pkg/core/curves"
 	"github.com/sei-protocol/sei-cryptography/pkg/encryption/elgamal"
 	testutils "github.com/sei-protocol/sei-cryptography/pkg/testing"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestZeroBalanceProof(t *testing.T) {
 	tests := []struct {
 		name               string
-		encryptAmount      uint64
+		encryptAmount      *big.Int
 		useDifferentPubKey bool
 		expectValid        bool
 	}{
 		{
 			name:               "Valid Proof - Correct Encryption and Commitment",
-			encryptAmount:      0,
+			encryptAmount:      big.NewInt(0),
 			useDifferentPubKey: false,
 			expectValid:        true,
 		},
 		{
 			name:               "Invalid Proof - Non-Zero Value",
-			encryptAmount:      10000,
+			encryptAmount:      big.NewInt(10000),
 			useDifferentPubKey: false,
 			expectValid:        false,
 		},
 		{
 			name:               "Invalid Proof - Different Public Key",
-			encryptAmount:      0,
+			encryptAmount:      big.NewInt(0),
 			useDifferentPubKey: true,
 			expectValid:        false,
 		},
@@ -78,7 +80,7 @@ func TestZeroBalanceProof_MarshalUnmarshalJSON(t *testing.T) {
 	eg := elgamal.NewTwistedElgamal()
 	keypair, _ := eg.KeyGen(*privateKey, TestDenom)
 
-	ciphertext, _, _ := eg.Encrypt(keypair.PublicKey, 0)
+	ciphertext, _, _ := eg.Encrypt(keypair.PublicKey, big.NewInt(0))
 	original, err := NewZeroBalanceProof(keypair, ciphertext)
 	require.NoError(t, err, "Proof generation should not produce an error")
 
@@ -105,7 +107,7 @@ func TestZeroBalanceProof_InvalidRandomness(t *testing.T) {
 	keypair, err := eg.KeyGen(*privateKey, TestDenom)
 	require.NoError(t, err, "Failed to generate key pair")
 
-	ciphertext, _, err := eg.Encrypt(keypair.PublicKey, 0)
+	ciphertext, _, err := eg.Encrypt(keypair.PublicKey, big.NewInt(0))
 	require.NoError(t, err, "Failed to encrypt amount")
 
 	curve := curves.ED25519()
@@ -132,7 +134,7 @@ func TestZeroBalanceProof_ExtremelyLargeScalars(t *testing.T) {
 	keypair, err := eg.KeyGen(*privateKey, TestDenom)
 	require.NoError(t, err, "Failed to generate key pair")
 
-	ciphertext, _, err := eg.Encrypt(keypair.PublicKey, 0)
+	ciphertext, _, err := eg.Encrypt(keypair.PublicKey, big.NewInt(0))
 	require.NoError(t, err, "Failed to encrypt amount")
 
 	// Manually set Z to an extremely large scalar
@@ -162,7 +164,7 @@ func TestZeroBalanceProof_TamperedProof(t *testing.T) {
 	keypair, err := eg.KeyGen(*privateKey, TestDenom)
 	require.NoError(t, err, "Failed to generate key pair")
 
-	ciphertext, _, err := eg.Encrypt(keypair.PublicKey, 0)
+	ciphertext, _, err := eg.Encrypt(keypair.PublicKey, big.NewInt(0))
 	require.NoError(t, err, "Failed to encrypt amount")
 
 	// Generate ZeroBalanceProof
@@ -236,7 +238,7 @@ func TestVerifyZeroProof_InvalidInput(t *testing.T) {
 	keypair, err := eg.KeyGen(*privateKey, TestDenom)
 	require.NoError(t, err, "Failed to generate key pair")
 
-	ciphertext, _, err := eg.Encrypt(keypair.PublicKey, 0)
+	ciphertext, _, err := eg.Encrypt(keypair.PublicKey, big.NewInt(0))
 	require.NoError(t, err, "Failed to encrypt amount")
 
 	proof, err := NewZeroBalanceProof(keypair, ciphertext)


### PR DESCRIPTION
This library can technically work with amounts larger than uint64. (Except for decryption)

Accordingly, it is quite possible that values stored by the CT module in sei-chain can exceed uint64.

This PR enables this library to work with arbitrarily large big.Ints instead of being constrained to uint64s