### PR TITLE
Add validations for zero values

### DIFF
--- a/pkg/zkproofs/ciphertext_ciphertext_equality.go
+++ b/pkg/zkproofs/ciphertext_ciphertext_equality.go
@@ -68,15 +68,15 @@ func NewCiphertextCiphertextEqualityProof(
 
 	// Generate random scalars
 	curve := curves.ED25519()
-	ys, err := GenerateRandomScalar(curve)
+	ys, err := GenerateRandomNonZeroScalar(curve)
 	if err != nil {
 		return nil, err
 	}
-	yx, err := GenerateRandomScalar(curve)
+	yx, err := GenerateRandomNonZeroScalar(curve)
 	if err != nil {
 		return nil, err
 	}
-	yr, err := GenerateRandomScalar(curve)
+	yr, err := GenerateRandomNonZeroScalar(curve)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func VerifyCiphertextCiphertextEquality(
 		return false
 	}
 
-	// validate proof for nil values
+	// validate proof for nil and zero values
 	if !proof.validateContents() {
 		return false
 	}

--- a/pkg/zkproofs/ciphertext_ciphertext_equality.go
+++ b/pkg/zkproofs/ciphertext_ciphertext_equality.go
@@ -1,7 +1,6 @@
 package zkproofs
 
 import (
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 
@@ -68,10 +67,19 @@ func NewCiphertextCiphertextEqualityProof(
 	r := *destinationOpening
 
 	// Generate random scalars
-	ed25519 := curves.ED25519()
-	ys := ed25519.Scalar.Random(rand.Reader)
-	yx := ed25519.Scalar.Random(rand.Reader)
-	yr := ed25519.Scalar.Random(rand.Reader)
+	curve := curves.ED25519()
+	ys, err := GenerateRandomScalar(curve)
+	if err != nil {
+		return nil, err
+	}
+	yx, err := GenerateRandomScalar(curve)
+	if err != nil {
+		return nil, err
+	}
+	yr, err := GenerateRandomScalar(curve)
+	if err != nil {
+		return nil, err
+	}
 
 	eg := elgamal.NewTwistedElgamal()
 	G := eg.GetG()

--- a/pkg/zkproofs/ciphertext_ciphertext_equality.go
+++ b/pkg/zkproofs/ciphertext_ciphertext_equality.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+
 	"github.com/coinbase/kryptology/pkg/core/curves"
 	"github.com/sei-protocol/sei-cryptography/pkg/encryption/elgamal"
 )
@@ -133,16 +134,15 @@ func VerifyCiphertextCiphertextEquality(
 	sourceCiphertext *elgamal.Ciphertext,
 	destinationCiphertext *elgamal.Ciphertext,
 ) bool {
-	// validate proof for nil values
-	if proof == nil || proof.Y0 == nil || proof.Y1 == nil || proof.Y2 == nil || proof.Y3 == nil || proof.Zs == nil ||
-		proof.Zx == nil || proof.Zr == nil {
+	// validate inputs
+	if proof == nil || sourcePubKey == nil || destinationPubKey == nil ||
+		sourceCiphertext == nil || sourceCiphertext.C == nil || sourceCiphertext.D == nil ||
+		destinationCiphertext == nil || destinationCiphertext.C == nil || destinationCiphertext.D == nil {
 		return false
 	}
 
-	// validate other input
-	if sourcePubKey == nil || destinationPubKey == nil ||
-		sourceCiphertext == nil || sourceCiphertext.C == nil || sourceCiphertext.D == nil ||
-		destinationCiphertext == nil || destinationCiphertext.C == nil || destinationCiphertext.D == nil {
+	// validate proof for nil values
+	if !proof.validateContents() {
 		return false
 	}
 
@@ -211,6 +211,21 @@ func VerifyCiphertextCiphertextEquality(
 	rhsY3 := proof.Y3.Add(cDd)
 
 	return lhsY3.Equal(rhsY3)
+}
+
+func (c *CiphertextCiphertextEqualityProof) validateContents() bool {
+	// Validate that fields are not nil
+	if c == nil || c.Y0 == nil || c.Y1 == nil || c.Y2 == nil || c.Y3 == nil || c.Zs == nil ||
+		c.Zx == nil || c.Zr == nil {
+		return false
+	}
+
+	// Validate that fields are non zero. Though it is technically possible if the randomly generated scalars are zero, it is highly unlikely (1 in 2^255 chance)
+	if c.Y0.IsIdentity() || c.Y1.IsIdentity() || c.Y2.IsIdentity() || c.Y3.IsIdentity() || c.Zr.IsZero() || c.Zs.IsZero() || c.Zx.IsZero() {
+		return false
+	}
+
+	return true
 }
 
 // MarshalJSON for CiphertextCiphertextEqualityProof

--- a/pkg/zkproofs/ciphertext_ciphertext_equality_test.go
+++ b/pkg/zkproofs/ciphertext_ciphertext_equality_test.go
@@ -415,4 +415,40 @@ func TestVerifyCiphertextCiphertextEquality_InvalidInputs(t *testing.T) {
 		)
 		require.False(t, valid, "Proof verification should fail for nil destination ciphertext")
 	})
+
+	t.Run("Invalid Proof Params", func(t *testing.T) {
+		// Y2 is zero point
+		clone := *proof
+		clone.Y2 = curves.ED25519().NewIdentityPoint()
+		valid := VerifyCiphertextCiphertextEquality(
+			&clone,
+			&sourceKeypair.PublicKey,
+			&destinationKeypair.PublicKey,
+			sourceCiphertext,
+			sourceCiphertext,
+		)
+		require.False(t, valid, "Proof verification should fail for proof params with zero value")
+
+		clone = *proof
+		clone.Zx = curves.ED25519().Scalar.Zero()
+		valid = VerifyCiphertextCiphertextEquality(
+			&clone,
+			&sourceKeypair.PublicKey,
+			&destinationKeypair.PublicKey,
+			sourceCiphertext,
+			sourceCiphertext,
+		)
+		require.False(t, valid, "Proof verification should fail for proof params with zero value")
+
+		clone = *proof
+		clone.Y1 = nil
+		valid = VerifyCiphertextCiphertextEquality(
+			&clone,
+			&sourceKeypair.PublicKey,
+			&destinationKeypair.PublicKey,
+			sourceCiphertext,
+			sourceCiphertext,
+		)
+		require.False(t, valid, "Proof verification should fail for proof params with zero value")
+	})
 }

--- a/pkg/zkproofs/ciphertext_commitment_equality.go
+++ b/pkg/zkproofs/ciphertext_commitment_equality.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+
 	"github.com/coinbase/kryptology/pkg/core/curves"
 	"github.com/sei-protocol/sei-cryptography/pkg/encryption/elgamal"
 )
@@ -118,14 +119,13 @@ func VerifyCiphertextCommitmentEquality(
 	sourceCiphertext *elgamal.Ciphertext,
 	pedersenCommitment *curves.Point,
 ) bool {
-	// Validate proof
-	if proof == nil || proof.Y0 == nil || proof.Y1 == nil || proof.Y2 == nil || proof.Zs == nil || proof.Zx == nil ||
-		proof.Zr == nil {
+	// Validate input
+	if proof == nil || sourcePubKey == nil || sourceCiphertext == nil || pedersenCommitment == nil {
 		return false
 	}
 
-	// Validate input
-	if sourcePubKey == nil || sourceCiphertext == nil || pedersenCommitment == nil {
+	// Validate proof
+	if !proof.validateContents() {
 		return false
 	}
 
@@ -174,6 +174,18 @@ func VerifyCiphertextCommitmentEquality(
 	rhsY2 := cCPed.Add(proof.Y2) // c * cPed + Y2
 
 	return lhsY2.Equal(rhsY2)
+}
+
+func (c *CiphertextCommitmentEqualityProof) validateContents() bool {
+	if c.Y0 == nil || c.Y1 == nil || c.Y2 == nil || c.Zs == nil || c.Zx == nil || c.Zr == nil {
+		return false
+	}
+
+	if c.Y0.IsIdentity() || c.Y1.IsIdentity() || c.Y2.IsIdentity() || c.Zs.IsZero() || c.Zx.IsZero() || c.Zr.IsZero() {
+		return false
+	}
+
+	return true
 }
 
 // MarshalJSON for CiphertextCommitmentEqualityProof

--- a/pkg/zkproofs/ciphertext_commitment_equality.go
+++ b/pkg/zkproofs/ciphertext_commitment_equality.go
@@ -1,7 +1,6 @@
 package zkproofs
 
 import (
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 
@@ -60,11 +59,22 @@ func NewCiphertextCommitmentEqualityProof(
 	G := eg.GetG() // Fixed base point G
 	H := eg.GetH() // Fixed base point H
 
-	ed25519 := curves.ED25519()
 	// Generate random masking factors
-	ys := ed25519.Scalar.Random(rand.Reader)
-	yx := ed25519.Scalar.Random(rand.Reader)
-	yr := ed25519.Scalar.Random(rand.Reader)
+	curve := curves.ED25519()
+	ys, err := GenerateRandomScalar(curve)
+	if err != nil {
+		return nil, err
+	}
+
+	yx, err := GenerateRandomScalar(curve)
+	if err != nil {
+		return nil, err
+	}
+
+	yr, err := GenerateRandomScalar(curve)
+	if err != nil {
+		return nil, err
+	}
 
 	// Compute Y0 = ys * P
 	Y0 := P.Mul(ys)

--- a/pkg/zkproofs/ciphertext_commitment_equality.go
+++ b/pkg/zkproofs/ciphertext_commitment_equality.go
@@ -61,17 +61,17 @@ func NewCiphertextCommitmentEqualityProof(
 
 	// Generate random masking factors
 	curve := curves.ED25519()
-	ys, err := GenerateRandomScalar(curve)
+	ys, err := GenerateRandomNonZeroScalar(curve)
 	if err != nil {
 		return nil, err
 	}
 
-	yx, err := GenerateRandomScalar(curve)
+	yx, err := GenerateRandomNonZeroScalar(curve)
 	if err != nil {
 		return nil, err
 	}
 
-	yr, err := GenerateRandomScalar(curve)
+	yr, err := GenerateRandomNonZeroScalar(curve)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/zkproofs/ciphertext_commitment_equality_test.go
+++ b/pkg/zkproofs/ciphertext_commitment_equality_test.go
@@ -261,6 +261,39 @@ func TestVerifyCiphertextCommitmentEquality_InvalidInput(t *testing.T) {
 		require.False(t, valid, "Proof verification should fail for proof with nil fields")
 	})
 
+	t.Run("Invalid Proof Params", func(t *testing.T) {
+		// Y2 is zero point
+		clone := *proof
+		clone.Y2 = curves.ED25519().NewIdentityPoint()
+		valid := VerifyCiphertextCommitmentEquality(
+			&clone,
+			&sourceKeypair.PublicKey,
+			sourceCiphertext,
+			&sourceCiphertext.C,
+		)
+		require.False(t, valid, "Proof verification should fail for proof params with zero value")
+
+		clone = *proof
+		clone.Zx = curves.ED25519().Scalar.Zero()
+		valid = VerifyCiphertextCommitmentEquality(
+			&clone,
+			&sourceKeypair.PublicKey,
+			sourceCiphertext,
+			&sourceCiphertext.C,
+		)
+		require.False(t, valid, "Proof verification should fail for proof params with zero value")
+
+		clone = *proof
+		clone.Y1 = nil
+		valid = VerifyCiphertextCommitmentEquality(
+			&clone,
+			&sourceKeypair.PublicKey,
+			sourceCiphertext,
+			&sourceCiphertext.C,
+		)
+		require.False(t, valid, "Proof verification should fail for proof params with zero value")
+	})
+
 	t.Run("Invalid Source Public Key", func(t *testing.T) {
 		// Source public key is nil
 		valid := VerifyCiphertextCommitmentEquality(

--- a/pkg/zkproofs/ciphertext_validity.go
+++ b/pkg/zkproofs/ciphertext_validity.go
@@ -48,12 +48,12 @@ func NewCiphertextValidityProof(pedersenOpening *curves.Scalar, pubKey curves.Po
 
 	// Step 1: Generate random blinding factors for the proof
 	curve := curves.ED25519()
-	rBlind, err := GenerateRandomScalar(curve) // Blinding factor for random value r
+	rBlind, err := GenerateRandomNonZeroScalar(curve) // Blinding factor for random value r
 	if err != nil {
 		return nil, err
 	}
 
-	xBlind, err := GenerateRandomScalar(curve) // Blinding factor for random value x
+	xBlind, err := GenerateRandomNonZeroScalar(curve) // Blinding factor for random value x
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/zkproofs/ciphertext_validity.go
+++ b/pkg/zkproofs/ciphertext_validity.go
@@ -88,8 +88,11 @@ func NewCiphertextValidityProof(pedersenOpening *curves.Scalar, pubKey curves.Po
 // - ciphertext: The ciphertext to prove the validity of.
 func VerifyCiphertextValidity(proof *CiphertextValidityProof, pubKey curves.Point, ciphertext *elgamal.Ciphertext) bool {
 	// Validate input
-	if proof == nil || proof.Commitment1 == nil || proof.Commitment2 == nil || proof.Response1 == nil ||
-		proof.Response2 == nil || pubKey == nil || ciphertext == nil || ciphertext.C == nil || ciphertext.D == nil {
+	if proof == nil || pubKey == nil || ciphertext == nil || ciphertext.C == nil || ciphertext.D == nil {
+		return false
+	}
+
+	if !proof.validateContents() {
 		return false
 	}
 
@@ -117,6 +120,18 @@ func VerifyCiphertextValidity(proof *CiphertextValidityProof, pubKey curves.Poin
 
 	// Step 3: Check if the recomputed commitments match the original commitments
 	return recomputedCommitment1.Equal(proof.Commitment1) && recomputedCommitment2.Equal(proof.Commitment2)
+}
+
+func (p *CiphertextValidityProof) validateContents() bool {
+	if p.Commitment1 == nil || p.Commitment2 == nil || p.Response1 == nil || p.Response2 == nil {
+		return false
+	}
+
+	if p.Commitment1.IsIdentity() || p.Commitment2.IsIdentity() || p.Response1.IsZero() || p.Response2.IsZero() {
+		return false
+	}
+
+	return true
 }
 
 // MarshalJSON for CiphertextValidityProof

--- a/pkg/zkproofs/ciphertext_validity.go
+++ b/pkg/zkproofs/ciphertext_validity.go
@@ -1,7 +1,6 @@
 package zkproofs
 
 import (
-	crand "crypto/rand"
 	"encoding/json"
 	"errors"
 	"math/big"
@@ -48,8 +47,16 @@ func NewCiphertextValidityProof(pedersenOpening *curves.Scalar, pubKey curves.Po
 	x, _ := ed25519.Scalar.SetBigInt(message)
 
 	// Step 1: Generate random blinding factors for the proof
-	rBlind := ed25519.Scalar.Random(crand.Reader) // Blinding factor for random value r
-	xBlind := ed25519.Scalar.Random(crand.Reader) // Blinding factor for random value x
+	curve := curves.ED25519()
+	rBlind, err := GenerateRandomScalar(curve) // Blinding factor for random value r
+	if err != nil {
+		return nil, err
+	}
+
+	xBlind, err := GenerateRandomScalar(curve) // Blinding factor for random value x
+	if err != nil {
+		return nil, err
+	}
 
 	// Step 2: Create commitments
 	rBlindH := H.Mul(rBlind)            // rBlind * H

--- a/pkg/zkproofs/ciphertext_validity_test.go
+++ b/pkg/zkproofs/ciphertext_validity_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/coinbase/kryptology/pkg/core/curves"
 	"github.com/sei-protocol/sei-cryptography/pkg/encryption/elgamal"
 	testutils "github.com/sei-protocol/sei-cryptography/pkg/testing"
 	"github.com/stretchr/testify/require"
@@ -153,6 +154,30 @@ func TestVerifyCiphertextValidityProof_Invalid_Input(t *testing.T) {
 	t.Run("Invalid proof with nil fields", func(t *testing.T) {
 		validated := VerifyCiphertextValidity(&CiphertextValidityProof{}, keys.PublicKey, ciphertext)
 		require.False(t, validated, "Validation should fail for proof with nil fields")
+	})
+
+	t.Run("Invalid Proof Params", func(t *testing.T) {
+		// Y2 is zero point
+		clone := *proof
+		clone.Commitment1 = curves.ED25519().NewIdentityPoint()
+		valid := VerifyCiphertextValidity(
+			&clone, keys.PublicKey, ciphertext,
+		)
+		require.False(t, valid, "Proof verification should fail for proof params with zero value")
+
+		clone = *proof
+		clone.Response1 = curves.ED25519().Scalar.Zero()
+		valid = VerifyCiphertextValidity(
+			&clone, keys.PublicKey, ciphertext,
+		)
+		require.False(t, valid, "Proof verification should fail for proof params with zero value")
+
+		clone = *proof
+		clone.Commitment2 = nil
+		valid = VerifyCiphertextValidity(
+			&clone, keys.PublicKey, ciphertext,
+		)
+		require.False(t, valid, "Proof verification should fail for proof params with zero value")
 	})
 
 	t.Run("Invalid Public Key", func(t *testing.T) {

--- a/pkg/zkproofs/pubkey_validity.go
+++ b/pkg/zkproofs/pubkey_validity.go
@@ -1,7 +1,6 @@
 package zkproofs
 
 import (
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 
@@ -37,8 +36,13 @@ func NewPubKeyValidityProof(pubKey curves.Point, privKey curves.Scalar) (*PubKey
 
 	eg := elgamal.NewTwistedElgamal()
 	H := eg.GetH()
+	
 	// Prover generates a random scalar y
-	y := curves.ED25519().Scalar.Random(rand.Reader)
+	curve := curves.ED25519()
+	y, err := GenerateRandomScalar(curve)
+	if err != nil {
+		return nil, err
+	}
 
 	// Commitment Y = y * H
 	Y := H.Mul(y)

--- a/pkg/zkproofs/pubkey_validity.go
+++ b/pkg/zkproofs/pubkey_validity.go
@@ -36,10 +36,10 @@ func NewPubKeyValidityProof(pubKey curves.Point, privKey curves.Scalar) (*PubKey
 
 	eg := elgamal.NewTwistedElgamal()
 	H := eg.GetH()
-	
+
 	// Prover generates a random scalar y
 	curve := curves.ED25519()
-	y, err := GenerateRandomScalar(curve)
+	y, err := GenerateRandomNonZeroScalar(curve)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/zkproofs/pubkey_validity.go
+++ b/pkg/zkproofs/pubkey_validity.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+
 	"github.com/coinbase/kryptology/pkg/core/curves"
 	"github.com/sei-protocol/sei-cryptography/pkg/encryption/elgamal"
 )
@@ -65,9 +66,12 @@ func NewPubKeyValidityProof(pubKey curves.Point, privKey curves.Scalar) (*PubKey
 // Parameters:
 // - pubKey: The PublicKey to validate.
 // - proof: The proof that the prover knows the corresponding PrivateKey.
-func VerifyPubKeyValidity(pubKey curves.Point, proof PubKeyValidityProof) bool {
+func VerifyPubKeyValidity(pubKey curves.Point, proof *PubKeyValidityProof) bool {
 	// Validate input
-	if pubKey == nil || proof.Y == nil || proof.Z == nil {
+	if proof == nil || pubKey == nil {
+		return false
+	}
+	if !proof.validateContents() {
 		return false
 	}
 
@@ -90,6 +94,18 @@ func VerifyPubKeyValidity(pubKey curves.Point, proof PubKeyValidityProof) bool {
 
 	// Check if z * H == c * P + Y
 	return lhs.Equal(rhs)
+}
+
+func (p *PubKeyValidityProof) validateContents() bool {
+	if p.Y == nil || p.Z == nil {
+		return false
+	}
+
+	if p.Y.IsIdentity() || p.Z.IsZero() {
+		return false
+	}
+
+	return true
 }
 
 // MarshalJSON for PubKeyValidityProof

--- a/pkg/zkproofs/pubkey_validity_test.go
+++ b/pkg/zkproofs/pubkey_validity_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/coinbase/kryptology/pkg/core/curves"
 	"github.com/sei-protocol/sei-cryptography/pkg/encryption/elgamal"
 	testutils "github.com/sei-protocol/sei-cryptography/pkg/testing"
 	"github.com/stretchr/testify/require"
@@ -77,15 +78,30 @@ func TestVerifyPubKeyValidityProof_InvalidInput(t *testing.T) {
 	require.Nil(t, err)
 
 	// Prove knowledge of the private key
-	proof, err := NewPubKeyValidityProof(keys.PublicKey, keys.PrivateKey)
+	validProof, err := NewPubKeyValidityProof(keys.PublicKey, keys.PrivateKey)
 	require.Nil(t, err)
 
 	// Verify the proof
-	valid := VerifyPubKeyValidity(nil, proof)
+	valid := VerifyPubKeyValidity(nil, validProof)
 	require.False(t, valid, "proof verification should fail for nil public key")
 
 	invalidProof := PubKeyValidityProof{}
 
 	valid = VerifyPubKeyValidity(keys.PublicKey, &invalidProof)
 	require.False(t, valid, "proof verification should fail for invalid proof")
+
+	invalidProof = *validProof
+	invalidProof.Y = curves.ED25519().NewIdentityPoint()
+	valid = VerifyPubKeyValidity(keys.PublicKey, &invalidProof)
+	require.False(t, valid, "proof verification should fail for invalid proof params")
+
+	invalidProof = *validProof
+	invalidProof.Z = curves.ED25519().Scalar.Zero()
+	valid = VerifyPubKeyValidity(keys.PublicKey, &invalidProof)
+	require.False(t, valid, "proof verification should fail for invalid proof params")
+
+	invalidProof = *validProof
+	invalidProof.Y = nil
+	valid = VerifyPubKeyValidity(keys.PublicKey, &invalidProof)
+	require.False(t, valid, "proof verification should fail for invalid proof params")
 }

--- a/pkg/zkproofs/pubkey_validity_test.go
+++ b/pkg/zkproofs/pubkey_validity_test.go
@@ -2,10 +2,11 @@ package zkproofs
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/sei-protocol/sei-cryptography/pkg/encryption/elgamal"
 	testutils "github.com/sei-protocol/sei-cryptography/pkg/testing"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestPubKeyValidityProof(t *testing.T) {
@@ -21,16 +22,16 @@ func TestPubKeyValidityProof(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the proof
-	valid := VerifyPubKeyValidity(keys.PublicKey, *proof)
+	valid := VerifyPubKeyValidity(keys.PublicKey, proof)
 	require.True(t, valid, "Valid Proof should be validated as true")
 
-	invalid := VerifyPubKeyValidity(altKeys.PublicKey, *proof)
+	invalid := VerifyPubKeyValidity(altKeys.PublicKey, proof)
 	require.False(t, invalid, "Proof should be invalid when trying to validate wrong PublicKey")
 
 	// Generate proof with the wrong private key.
 	badProof, err := NewPubKeyValidityProof(keys.PublicKey, altKeys.PrivateKey)
 	require.Nil(t, err)
-	invalid = VerifyPubKeyValidity(keys.PublicKey, *badProof)
+	invalid = VerifyPubKeyValidity(keys.PublicKey, badProof)
 	require.False(t, invalid, "Proof generated with wrong Privkey should be validated as false.")
 }
 
@@ -80,11 +81,11 @@ func TestVerifyPubKeyValidityProof_InvalidInput(t *testing.T) {
 	require.Nil(t, err)
 
 	// Verify the proof
-	valid := VerifyPubKeyValidity(nil, *proof)
+	valid := VerifyPubKeyValidity(nil, proof)
 	require.False(t, valid, "proof verification should fail for nil public key")
 
 	invalidProof := PubKeyValidityProof{}
 
-	valid = VerifyPubKeyValidity(keys.PublicKey, invalidProof)
+	valid = VerifyPubKeyValidity(keys.PublicKey, &invalidProof)
 	require.False(t, valid, "proof verification should fail for invalid proof")
 }

--- a/pkg/zkproofs/range_test.go
+++ b/pkg/zkproofs/range_test.go
@@ -301,5 +301,27 @@ func TestVerifyRangeProof_InvalidInput(t *testing.T) {
 		require.EqualError(t, err, "invalid ciphertext")
 		require.False(t, valid)
 	})
+}
 
+func TestRangeProofsPerformance(t *testing.T) {
+	value := big.NewInt(10)
+	n := 32 // the range is [0, 2^128]
+
+	privateKey, err := testutils.GenerateKey()
+	require.Nil(t, err, "Error generating private key")
+
+	eg := elgamal.NewTwistedElgamal()
+	keyPair, err := eg.KeyGen(*privateKey, TestDenom)
+	require.Nil(t, err, "Error generating key pair")
+
+	ciphertext, gamma, _ := eg.Encrypt(keyPair.PublicKey, value)
+
+	for i := 0; i < 100; i++ {
+		proof, err := NewRangeProof(n, value, gamma)
+		require.Nil(t, err)
+
+		verified, err := VerifyRangeProof(proof, ciphertext, n)
+		require.NoError(t, err)
+		require.True(t, verified)
+	}
 }

--- a/pkg/zkproofs/utils.go
+++ b/pkg/zkproofs/utils.go
@@ -7,9 +7,11 @@ import (
 	"github.com/coinbase/kryptology/pkg/core/curves"
 )
 
+// Generates a non-zero random scalar. The chances of generating a zero scalar are very low.
 func GenerateRandomScalar(curve *curves.Curve) (curves.Scalar, error) {
 	attempts := 0
 	scalar := curve.Scalar.Random(rand.Reader)
+	// Try 5 times to generate a non zero scalar. The chance that this fails with a normal random number generator is impossibly low.
 	for scalar.IsZero() && attempts < 5 {
 		curve.Scalar.Random(rand.Reader)
 		attempts += 1

--- a/pkg/zkproofs/utils.go
+++ b/pkg/zkproofs/utils.go
@@ -7,19 +7,21 @@ import (
 	"github.com/coinbase/kryptology/pkg/core/curves"
 )
 
-// Generates a non-zero random scalar. The chances of generating a zero scalar are very low.
-func GenerateRandomScalar(curve *curves.Curve) (curves.Scalar, error) {
-	attempts := 0
-	scalar := curve.Scalar.Random(rand.Reader)
-	// Try 5 times to generate a non zero scalar. The chance that this fails with a normal random number generator is impossibly low.
-	for scalar.IsZero() && attempts < 5 {
-		curve.Scalar.Random(rand.Reader)
-		attempts += 1
+// GenerateRandomNonZeroScalar Generates a non-zero random scalar.
+// Parameters:
+// - curve: The elliptic curve to use for scalar generation.
+// Returns:
+// - A non-zero random scalar.
+// - An error if the scalar generation fails.
+func GenerateRandomNonZeroScalar(curve *curves.Curve) (curves.Scalar, error) {
+	var scalar curves.Scalar
+
+	for attempts := 0; attempts < 5; attempts++ {
+		scalar = curve.Scalar.Random(rand.Reader)
+		if !scalar.IsZero() {
+			return scalar, nil
+		}
 	}
 
-	if scalar.IsZero() {
-		return nil, errors.New("failed to generate a non-zero scalar")
-	}
-
-	return scalar, nil
+	return nil, errors.New("failed to generate a non-zero scalar")
 }

--- a/pkg/zkproofs/utils.go
+++ b/pkg/zkproofs/utils.go
@@ -1,0 +1,23 @@
+package zkproofs
+
+import (
+	"crypto/rand"
+	"errors"
+
+	"github.com/coinbase/kryptology/pkg/core/curves"
+)
+
+func GenerateRandomScalar(curve *curves.Curve) (curves.Scalar, error) {
+	attempts := 0
+	scalar := curve.Scalar.Random(rand.Reader)
+	for scalar.IsZero() && attempts < 5 {
+		curve.Scalar.Random(rand.Reader)
+		attempts += 1
+	}
+
+	if scalar.IsZero() {
+		return nil, errors.New("failed to generate a non-zero scalar")
+	}
+
+	return scalar, nil
+}

--- a/pkg/zkproofs/utils_test.go
+++ b/pkg/zkproofs/utils_test.go
@@ -1,0 +1,21 @@
+package zkproofs
+
+import (
+	"testing"
+
+	"github.com/coinbase/kryptology/pkg/core/curves"
+)
+
+// Basic test for getting a non-zero scalar.
+func TestGenerateRandomNonZeroScalar(t *testing.T) {
+	scalar, err := GenerateRandomNonZeroScalar(curves.ED25519())
+
+	// The function throws an err if zero is generated after 5 tries.
+	// There should be a virtually 0 chance of this happening. It's most likely due to a randomness issue.
+	if err != nil {
+		t.Errorf("Failed to generate zero. This is improbable and probably an error")
+	}
+	if scalar.IsZero() {
+		t.Errorf("Expected non-zero scalar, got zero")
+	}
+}

--- a/pkg/zkproofs/zero_balance.go
+++ b/pkg/zkproofs/zero_balance.go
@@ -1,7 +1,6 @@
 package zkproofs
 
 import (
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 
@@ -38,7 +37,11 @@ func NewZeroBalanceProof(
 	D := ciphertext.D
 
 	// Generate random masking factor y
-	y := curves.ED25519().Scalar.Random(rand.Reader)
+	curve := curves.ED25519()
+	y, err := GenerateRandomScalar(curve)
+	if err != nil {
+		return nil, err
+	}
 
 	// Compute Yp = y * P and Yd = y * D
 	Yp := P.Mul(y)

--- a/pkg/zkproofs/zero_balance.go
+++ b/pkg/zkproofs/zero_balance.go
@@ -38,7 +38,7 @@ func NewZeroBalanceProof(
 
 	// Generate random masking factor y
 	curve := curves.ED25519()
-	y, err := GenerateRandomScalar(curve)
+	y, err := GenerateRandomNonZeroScalar(curve)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/zkproofs/zero_balance.go
+++ b/pkg/zkproofs/zero_balance.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+
 	"github.com/coinbase/kryptology/pkg/core/curves"
 	"github.com/sei-protocol/sei-cryptography/pkg/encryption/elgamal"
 )
@@ -71,8 +72,10 @@ func VerifyZeroBalance(
 	pubKey *curves.Point,
 	ciphertext *elgamal.Ciphertext,
 ) bool {
-	if proof == nil || proof.Yp == nil || proof.Yd == nil || proof.Z == nil || pubKey == nil ||
-		ciphertext == nil || ciphertext.C == nil || ciphertext.D == nil {
+	if proof == nil || pubKey == nil || ciphertext == nil || ciphertext.C == nil || ciphertext.D == nil {
+		return false
+	}
+	if !proof.validateContents() {
 		return false
 	}
 
@@ -107,6 +110,18 @@ func VerifyZeroBalance(
 	rhsYd := cC.Add(proof.Yd) // c * C + Yd
 
 	return lhsYd.Equal(rhsYd)
+}
+
+func (p *ZeroBalanceProof) validateContents() bool {
+	if p.Yp == nil || p.Yd == nil || p.Z == nil {
+		return false
+	}
+
+	if p.Yp.IsIdentity() || p.Yd.IsIdentity() || p.Z.IsZero() {
+		return false
+	}
+
+	return true
 }
 
 // MarshalJSON for ZeroBalanceProof

--- a/pkg/zkproofs/zero_balance_test.go
+++ b/pkg/zkproofs/zero_balance_test.go
@@ -279,4 +279,19 @@ func TestVerifyZeroProof_InvalidInput(t *testing.T) {
 	}
 	valid = VerifyZeroBalance(invalidProof, &keypair.PublicKey, ciphertext)
 	require.False(t, valid, "Verification should fail with invalid proof values")
+
+	invalidParamsProof := *proof
+	invalidParamsProof.Yp = curves.ED25519().NewIdentityPoint()
+	valid = VerifyZeroBalance(&invalidParamsProof, &keypair.PublicKey, ciphertext)
+	require.False(t, valid, "Verification should fail with invalid proof params")
+
+	invalidParamsProof = *proof
+	invalidParamsProof.Z = curves.ED25519().Scalar.Zero()
+	valid = VerifyZeroBalance(&invalidParamsProof, &keypair.PublicKey, ciphertext)
+	require.False(t, valid, "Verification should fail with invalid proof params")
+
+	invalidParamsProof = *proof
+	invalidParamsProof.Yd = nil
+	valid = VerifyZeroBalance(&invalidParamsProof, &keypair.PublicKey, ciphertext)
+	require.False(t, valid, "Verification should fail with invalid proof params")
 }


### PR DESCRIPTION
This PR:
- Adds validations for each VerifyXProof method to ensure that the components of the proof are not nil and also not zero or the identity point (The zero point of the curve)
- Adds a method to ensure that we do not generate 0 when generating scalars

Explaination:
As part of the audit, a bug was caught where by generating the CiphertextCommitment proof in a certain way
1. Setting the yx, yr to k*x and k*r instead of random values (Where k is an arbitrary scalar value)
2. Setting Y2 to 0
the attacker can get the ValidateCiphertextCommitment to return true even though the Ciphertext and Commitment encrypt different values.
Specifically, the commitment must encrypt x * (c + k) * c_inv, where
k is any random scalar
x is the original value encrypted by the ciphertext
c is the challenge scalar of the proof, which can be independently generated using the params in the proof
The implication is that the attacker would be able to create a transfer/withdrawal for more than they have.
Eg:
Account state: AvailableBalance: 100
Withdraw {
    WithdrawAmount: 150 (Exceeds AvailableBalance)
    NewAvailableBalanceCommitment: (-50 * (c + k) * c_inv) - This is a specific value calculated by the attacker.
    RangeProof that NewAvailableBalanceCommitment is > 0 - This will pass assuming the fake NewAvailableBalanceCommitment above is +ve
    EqualityProof that NewAvailableBalance == Account.AvailableBalance - WithdrawAmount - This is the fake equality proof
}
This withdraw instruction will pass, since the range proof is valid and the equality proof is valid.

This can be mitigated by adding zero checks to the proof. 
While this was only flagged for the proof above, this PR adds zero checks to all the parameters in the proof.

Zero values in the proof could suggest a lack of randomness when generating scalars and lead to degraded proofs, since the values may no longer be blinded, or the proof could be exploited in some edge case.

In all of the cases for our proofs, zero values arise when a random scalar we generate is 0 or specifically cancels out another value. Since we generate random scalars on a field of 2^255 points, the probability of generating such a scalar is 1/(2^255) and effectively negligible

Since we still want to eliminate random chance failures due to generating 0, also adds a method to make it impossible to generate the 0 value randomly when we generate random scalars, failing on the proof generation side if it happens instead of at validation time.