### PR TITLE
Fix bugs in Zero Balance Verification

### DIFF
--- a/pkg/zkproofs/zero_balance.go
+++ b/pkg/zkproofs/zero_balance.go
@@ -120,7 +120,8 @@ func (p *ZeroBalanceProof) validateContents() bool {
 		return false
 	}
 
-	if p.Yp.IsIdentity() || p.Yd.IsIdentity() || p.Z.IsZero() {
+	// We leave out p.Yd since it is valid for Yd to be zero (Ciphertext.D can be Identity point)
+	if p.Yp.IsIdentity() || p.Z.IsZero() {
 		return false
 	}
 

--- a/pkg/zkproofs/zero_balance_test.go
+++ b/pkg/zkproofs/zero_balance_test.go
@@ -295,3 +295,24 @@ func TestVerifyZeroProof_InvalidInput(t *testing.T) {
 	valid = VerifyZeroBalance(&invalidParamsProof, &keypair.PublicKey, ciphertext)
 	require.False(t, valid, "Verification should fail with invalid proof params")
 }
+
+func TestZeroBalanceProof_IdentityD(t *testing.T) {
+	// Setup keypair
+	privateKey, _ := testutils.GenerateKey()
+
+	eg := elgamal.NewTwistedElgamal()
+	keypair, _ := eg.KeyGen(*privateKey, TestDenom)
+
+	ciphertext, _, err := eg.Encrypt(keypair.PublicKey, big.NewInt(100))
+	require.NoError(t, err, "Failed to encrypt amount")
+
+	ciphertextZero, _ := elgamal.SubtractCiphertext(ciphertext, ciphertext)
+
+	// Generate ZeroBalanceProof
+	proof, err := NewZeroBalanceProof(keypair, ciphertextZero)
+	require.NoError(t, err, "Failed to generate proof")
+
+	// Verify the proof
+	valid := VerifyZeroBalance(proof, &keypair.PublicKey, ciphertextZero)
+	require.True(t, valid, "Proof should be valid")
+}


### PR DESCRIPTION
In the fix for the audit, we added validations to ensure that none of the fields of proofs should be Zero or the Identity Point. This makes sense for most fields since they are computed via randomly generated scalars and it is near impossible for them to be zero (Those fields being zero would suggest tampering with the proof)

However, in this one case, it is possible and even common for the Yd field of a zero proof to be the identity point.
Since Yd is computed as D.Mul(y) where D is the D component of a ciphertext and y is a randomly generated scalar, Yd is zero when y is generated as zero (no longer possible) or if D is zero.

D of a ciphertext is zero (identity point) when we perform a subtraction of a ciphertext on itself. This is what we do to zero out fields in apply pending balances and is not an uncommon scenario. This means that we it is possible for Yd to be identity point and we should remove that validation.

Also checked other fields and added tests for other fields where this could be possible and confirmed that this doesn't apply apply to other fields, so we can leave the rest of the validations in place.
